### PR TITLE
Add labels to pull requests in full releases

### DIFF
--- a/chart/go-ship-it/Chart.yaml
+++ b/chart/go-ship-it/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This would be cool to do with milestones instead, but they require the graphql api, which is a bit more difficult to do

```release-note
Add labels to pull requests, when they are included in a full release
```
