### PR TITLE
Fix helm linting

### DIFF
--- a/chart/go-ship-it/Chart.yaml
+++ b/chart/go-ship-it/Chart.yaml
@@ -1,21 +1,11 @@
-apiVersion: v2
+apiVersion: v1
 name: go-ship-it
 description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Downgrade the helm apiVersion in the chart to v1.

Apparently the values are reordered when pushed to external registry in v2, which causes diffs on every pull request
