### PR TITLE
Support target branch configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	github.com/spf13/viper v1.7.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/gookit/color.v1 v1.1.6
+	gopkg.in/yaml.v2 v2.2.8
 )


### PR DESCRIPTION
- Get behavior configuration from a `.ship-it` file in the root of the repository, before handling events
- Support specifying a target branch in `.ship-it`

This is part of a solution to #19 

```release-note
Allow users to specify which branch go-ship-it should monitor in .ship-it
```