### PR TITLE
Graceful handling of missing .ship-it

### DIFF
--- a/internal/rest/v1/webhook.go
+++ b/internal/rest/v1/webhook.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -39,6 +40,11 @@ func (h *Handler) HandleGithub(c echo.Context, entry *logrus.Entry) error {
 		l := entry.WithField("repo", event.GetRepo().GetFullName())
 		r, err := h.initReleaser(c, event, event.GetRepo(), event.GetHead(), l)
 		if err != nil {
+			if errors.Is(err, scm.ErrConfMissing) {
+				l.WithError(err).Debug("Configuration missing from repository. Discarding event")
+
+				return c.String(http.StatusNotFound, ".ship-it missing from repo. Event discarded")
+			}
 			l.WithError(err).Error("Could not initialize releaser")
 
 			return err
@@ -50,6 +56,11 @@ func (h *Handler) HandleGithub(c echo.Context, entry *logrus.Entry) error {
 		l := entry.WithField("repo", event.GetRepo().GetFullName())
 		r, err := h.initReleaser(c, event, event.GetRepo(), event.GetRelease().GetTagName(), l)
 		if err != nil {
+			if errors.Is(err, scm.ErrConfMissing) {
+				l.WithError(err).Debug("Configuration missing from repository. Discarding event")
+
+				return c.String(http.StatusNotFound, ".ship-it missing from repo. Event discarded")
+			}
 			l.WithError(err).Error("Could not initialize releaser")
 
 			return err

--- a/internal/rest/v1/webhook.go
+++ b/internal/rest/v1/webhook.go
@@ -20,7 +20,7 @@ func (h *Handler) initReleaser(c echo.Context, ev HandledGithubEvent, repo scm.R
 	k := ghinstallation.NewFromAppsTransport(h.AppsTransport, ev.GetInstallation().GetID())
 	client := scm.NewGithubClient(&http.Client{Transport: k, Timeout: time.Minute}, repo)
 
-	return scm.NewReleaser(c.Request().Context(), client, ref, entry.WithField("repo", repo.GetFullName()))
+	return scm.NewReleaser(c.Request().Context(), client, ref, entry)
 }
 
 func (h *Handler) HandleGithub(c echo.Context, entry *logrus.Entry) error {
@@ -36,9 +36,10 @@ func (h *Handler) HandleGithub(c echo.Context, entry *logrus.Entry) error {
 
 	switch event := event.(type) {
 	case *github.PushEvent:
-		r, err := h.initReleaser(c, event, event.GetRepo(), event.GetHead(), entry)
+		l := entry.WithField("repo", event.GetRepo().GetFullName())
+		r, err := h.initReleaser(c, event, event.GetRepo(), event.GetHead(), l)
 		if err != nil {
-			entry.WithError(err).Error("Could not initialize releaser")
+			l.WithError(err).Error("Could not initialize releaser")
 
 			return err
 		}
@@ -46,9 +47,10 @@ func (h *Handler) HandleGithub(c echo.Context, entry *logrus.Entry) error {
 
 		return c.String(http.StatusAccepted, "Handling push event")
 	case *github.ReleaseEvent:
-		r, err := h.initReleaser(c, event, event.GetRepo(), event.GetRelease().GetTagName(), entry)
+		l := entry.WithField("repo", event.GetRepo().GetFullName())
+		r, err := h.initReleaser(c, event, event.GetRepo(), event.GetRelease().GetTagName(), l)
 		if err != nil {
-			entry.WithError(err).Error("Could not initialize releaser")
+			l.WithError(err).Error("Could not initialize releaser")
 
 			return err
 		}

--- a/internal/scm/github.go
+++ b/internal/scm/github.go
@@ -150,10 +150,17 @@ func (c *GithubClientImpl) GetPullsInCommitRange(ctx context.Context, commits []
 	return pulls, nil
 }
 
+var (
+	ErrFileMissing = errors.New("File missing in repository")
+)
+
 func (c *GithubClientImpl) GetFile(ctx context.Context, ref, file string) (io.ReadCloser, error) {
-	r, _, err := c.client.Repositories.DownloadContents(ctx, c.repo.GetOwner().GetLogin(), c.repo.GetName(), file, &github.RepositoryContentGetOptions{
+	r, o, err := c.client.Repositories.DownloadContents(ctx, c.repo.GetOwner().GetLogin(), c.repo.GetName(), file, &github.RepositoryContentGetOptions{
 		Ref: ref,
 	})
+	if o.StatusCode == http.StatusNotFound {
+		return nil, ErrFileMissing
+	}
 	return r, err
 }
 

--- a/internal/scm/releaser.go
+++ b/internal/scm/releaser.go
@@ -25,6 +25,7 @@ var (
 	configValidator = validator.New()
 	candidateRx     = regexp.MustCompile("^rc.(?P<candidate>[0-9]+)$")
 	changelogRx     = regexp.MustCompile("```release-note([\\s\\S]*?)```")
+	ErrConfMissing  = errors.New("Missing .ship-it file")
 )
 
 type LabelsConfig struct {
@@ -55,6 +56,9 @@ func getConfig(ctx context.Context, c GithubClient, ref string) (*Config, error)
 	}
 	reader, err := c.GetFile(ctx, ref, ".ship-it")
 	if err != nil {
+		if errors.Is(err, ErrFileMissing) {
+			return nil, ErrConfMissing
+		}
 		return nil, errors.Wrap(err, "Failed to get .ship-it file for configuration")
 	}
 	defer reader.Close()


### PR DESCRIPTION
```release-note
Return a 404 instead of 500 when handling webhook event from a repo without a .ship-it
```

