### PR TITLE
Fix github changelog in promotion flow

### DIFF
--- a/internal/scm/releaser.go
+++ b/internal/scm/releaser.go
@@ -309,8 +309,9 @@ func (r *Releaser) Promote(ctx context.Context, release *github.RepositoryReleas
 	}
 
 	rel, err := r.client.EditRelease(ctx, release.GetID(), &github.RepositoryRelease{
-		TagName: github.String(fmt.Sprintf("v%s", full.String())),
-		Name:    github.String(full.String()),
+		TagName:              github.String(fmt.Sprintf("v%s", full.String())),
+		Name:                 github.String(full.String()),
+		GenerateReleaseNotes: github.Bool(r.config.Changelog.Type == "github"),
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to edit release '%d'", release.GetID())

--- a/internal/scm/releaser.go
+++ b/internal/scm/releaser.go
@@ -308,10 +308,19 @@ func (r *Releaser) Promote(ctx context.Context, release *github.RepositoryReleas
 		return nil, errors.Wrapf(err, "Failed to create reference '%s'", full.String())
 	}
 
+	var changelog *string = nil
+	if r.config.Changelog.Type == "github" {
+		notes, err := r.client.GenerateReleaseNotes(ctx, fmt.Sprintf("v%s", full.String()))
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to generate release notes for '%s'", full.String())
+		}
+		changelog = &notes.Body
+	}
+
 	rel, err := r.client.EditRelease(ctx, release.GetID(), &github.RepositoryRelease{
-		TagName:              github.String(fmt.Sprintf("v%s", full.String())),
-		Name:                 github.String(full.String()),
-		GenerateReleaseNotes: github.Bool(r.config.Changelog.Type == "github"),
+		TagName: github.String(fmt.Sprintf("v%s", full.String())),
+		Name:    github.String(full.String()),
+		Body:    changelog,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to edit release '%d'", release.GetID())


### PR DESCRIPTION
Regenerate release notes in release promotion when using github autogenerated release notes

The current implementation reuses the notes from the pre-release, which includes a link to the old pre-release tag compared to the previous release. This PR fixes that problem